### PR TITLE
Separate activities from people user is following from internet people

### DIFF
--- a/dashboard.css
+++ b/dashboard.css
@@ -15,37 +15,32 @@
 #dashboard .news > .repo,
 #dashboard .news > .tag,
 #dashboard .news > .team_add,
+#dashboard .news > .member_add,
 #dashboard .news > .watch_started {
   display: none;
 }
 
-#dashboard.show_stars .news > .watch_started {
+#dashboard.show_starred_and_followed_by .news > .watch_started.by_internet,
+#dashboard.show_starred_and_followed_by .news > .follow.by_internet {
   display: block;
 }
 
-#dashboard.show_wiki .news > .gollum {
+#dashboard.show_forked_by .news > .fork.by_internet {
   display: block;
 }
 
-#dashboard.show_follow .news > .follow {
+#dashboard.show_stars_and_follows .news > .watch_started.by_followed_people,
+#dashboard.show_stars_and_follows .news > .follow.by_followed_people {
   display: block;
 }
 
-#dashboard.show_forks .news > .fork {
+#dashboard.show_forks .news > .fork.by_followed_people {
   display: block;
 }
 
-#dashboard.show_org_admin .news > .team_add {
-  display: block;
-}
-
-#dashboard.show_comments .news > .issues_comment,
-#dashboard.show_comments .news > .commit_comment {
-  display: block;
-}
-
-#dashboard.show_open_source .news > .repo,
-#dashboard.show_open_source .news > .public {
+#dashboard.show_open_source .news > .repo.by_followed_people,
+#dashboard.show_open_source .news > .create.by_followed_people,
+#dashboard.show_open_source .news > .public.by_followed_people {
   display: block;
 }
 
@@ -54,16 +49,23 @@
   display: block;
 }
 
-#dashboard.show_pushes .news > .create,
-#dashboard.show_pushes .news > .git-branch,
-#dashboard.show_pushes .news > .push {
+#dashboard.show_code .news > .gollum,
+#dashboard.show_code .news > .git-branch,
+#dashboard.show_code .news > .push {
   display: block;
 }
 
-#dashboard.show_issues .news > .issues_opened,
-#dashboard.show_issues .news > .issues_labeled,
-#dashboard.show_issues .news > .issues_closed,
-#dashboard.show_issues .news > .issues_reopened {
+#dashboard.show_conversations .news > .issues_comment,
+#dashboard.show_conversations .news > .commit_comment,
+#dashboard.show_conversations .news > .issues_opened,
+#dashboard.show_conversations .news > .issues_labeled,
+#dashboard.show_conversations .news > .issues_closed,
+#dashboard.show_conversations .news > .issues_reopened {
+  display: block;
+}
+
+#dashboard.show_administration .news > .team_add,
+#dashboard.show_administration .news > .member_add {
   display: block;
 }
 

--- a/dashboard.js
+++ b/dashboard.js
@@ -1,7 +1,47 @@
-const events = ['Open Source', 'Conversation --', 'Issues', 'Comments', 'Code --', 'Pushes', 'Releases', 'Forks', 'Wiki', 'Community --', 'Stars', 'Follow', 'Organization admin']
-var paginateProgress = 0
+// Could break if GitHub changes its markup
+const context = document.querySelector('#org_your_repos') ? 'org' : 'user'
+const menuItems = {
+  user: [
+    'Watched repositories --',
+    'Code',
+    'Releases',
+    'Conversations',
+    'Following --',
+    'Open source',
+    'Stars and follows',
+    'Forks',
+    'You --',
+    'Starred and followed by',
+    'Forked by'
+  ],
+  org: [
+    'Code',
+    'Releases',
+    'Conversations',
+    'Administration'
+  ]
+}
+
+const events = [
+  // Code
+  'git-branch', 'push', 'gollum',
+  // Releases
+  'release', 'tag',
+  // Conversations
+  'issues_closed', 'issues_labeled', 'issues_opened', 'issues_reopened', 'commit_comment', 'issues_comment',
+  // Open source
+  'create', 'public', 'repo',
+  // Stars and follows / Starred and followed by
+  'watch_started', 'follow',
+  // Forks / Forked by
+  'fork',
+  // Administration
+  'team_add', 'member_add'
+]
+
 init()
 updateClasses()
+if (context === 'user') specifyTimelineEvents()
 
 document.addEventListener('change', function (evt) {
   if (evt.target.classList.contains('js-dashboard-filter-checkbox')) {
@@ -35,24 +75,24 @@ function init () {
   summary.innerText = 'Filter'
   const container = document.createElement('div')
   container.classList.add('dropdown-menu', 'dropdown-menu-se', 'f5')
-  container.style.width = '200px'
+  container.style.width = '260px'
 
-  for (const key of events) {
-    var isHeader = key.split(/ --$/)
+  for (const key of menuItems[context]) {
+    const isHeader = key.split(/ --$/)
     if (isHeader.length > 1) {
-      var header = document.createElement('div')
+      const header = document.createElement('div')
       header.textContent = isHeader[0]
       header.classList.add('dropdown-header')
       container.appendChild(header)
       continue
     }
-    var id = key.toLowerCase().replace(/\s/g, '_')
-    var input = document.createElement('input')
+    const id = key.toLowerCase().replace(/\s/g, '_').replace(/\/_/g, '')
+    const input = document.createElement('input')
     input.type = 'checkbox'
     input.id = id
     input.className = 'position-absolute my-2 ml-3 js-dashboard-filter-checkbox'
 
-    var label = document.createElement('label')
+    const label = document.createElement('label')
     label.className = 'pl-6 dropdown-item js-dashboard-filter-label'
     label.innerText = key
     label.htmlFor = id
@@ -63,61 +103,93 @@ function init () {
   details.appendChild(summary)
   details.appendChild(container)
 
-  var newDashboard = document.querySelector('.page-responsive [data-src*="/dashboard/recent-activity"]')
+  const newDashboard = document.querySelector('.page-responsive [data-src*="/dashboard/recent-activity"]')
   if (newDashboard) {
     newDashboard.after(details)
   } else {
     // org or user condition
     summary.classList.remove('btn-sm')
-    details.classList.add(document.querySelector('#org_your_repos') ? 'mt-3' : 'mt-5')
+    details.classList.add(isOrg ? 'mt-3' : 'mt-5')
     document.querySelector('.news').prepend(details)
   }
   applyPreference()
 }
 
 function rememberPreference () {
-  var preference = {}
+  const preference = JSON.parse(localStorage.getItem(`dashboard:select:${context}`) || '{}')
   for (const box of document.querySelectorAll('.js-dashboard-filter-checkbox')) {
     preference[box.id] = box.checked
   }
 
-  localStorage.setItem('dashboard:select', JSON.stringify(preference))
-  loadMoreItemsIfApplicable()
+  localStorage.setItem(`dashboard:select:${context}`, JSON.stringify(preference))
 }
 
 function applyPreference () {
-  var preference = localStorage.getItem('dashboard:select')
-  if (preference) {
-    preference = JSON.parse(preference)
-  }
+  const preference = JSON.parse(localStorage.getItem(`dashboard:select:${context}`) || '{}')
 
   for (const box of document.querySelectorAll('.js-dashboard-filter-checkbox')) {
-    box.checked = preference ? preference[box.id] : true
+    box.checked = (typeof preference[box.id] === 'boolean') ? preference[box.id] : true
   }
-
-  loadMoreItemsIfApplicable()
 }
 
-function loadMoreItemsIfApplicable (looping) {
-  var paginateBtn = document.querySelector('#dashboard button.ajax-pagination-btn')
-  if (!paginateBtn) { return false }
-  if (!looping) { paginateProgress = 0 }
-  paginateBtn.click()
+function specifyTimelineEvents() {
+  const dashboard = document.querySelector('#dashboard .news')
+  if (!dashboard) return
+  const observer = new MutationObserver(addMoreSpecificIdentifiers)
+  observer.observe(dashboard, {subtree: true, childList: true})
+}
 
-  var classes = events.map(function(event){ return event.toLowerCase()}).join(',')
-  var visibleItems = Array.prototype.filter.call(document.querySelectorAll(classes), function (ele) {
-    return ele.offsetHeight > 0
-  })
+async function getFollowingList() {
+  console.log('Dashboard extension: getting list of people you follow from localStorage')
+  const following = localStorage.getItem('dashboard:following')
+  if (!following || (following && (new Date().getTime() - new Date(JSON.parse(following).updatedAt))/1000 > 24*60*60)) {
+    const results = await fetchFollowing()
+    const following = {
+      updatedAt: (new Date()).getTime(),
+      following: results
+    }
+    localStorage.setItem('dashboard:following', JSON.stringify(following))
+    return results
+  } else {
+    return JSON.parse(following).following
+  }
+}
 
-  if (visibleItems.length < 10) {
-    paginateBtn.click()
-
-    // Ugh
-    setTimeout(function () {
-      if (paginateProgress < 3 && visibleItems.length < 10) {
-        paginateProgress++
-        loadMoreItemsIfApplicable(true)
+async function fetchFollowing() {
+  console.log('Dashboard extension: updating list of people you follow from GitHub API (once every 24h)')
+  return new Promise(async function(resolve) {
+    let following = []
+    const user = document.querySelector('.HeaderNavlink.name').pathname.slice(1)
+    const endpoint = `https://api.github.com/users/${user}/following`
+    let page = 1
+    while (page > 0) {
+      const res = await fetch(`${endpoint}?page=${page}`)
+      const people = await res.json()
+      following = following.concat(people)
+      if (people.length === 30) {
+        page++
+      } else {
+        page = 0
+        resolve(following.map(o => o.login))
       }
-    }, 500)
+    }
+  })
+}
+
+// Could break if GitHub changes its markup
+async function addMoreSpecificIdentifiers(list) {
+  const following = await getFollowingList()
+  for (const record of list) {
+    if (!record.target.classList.contains('news')) continue
+    for (const eventItem of record.addedNodes) {
+      if (!(eventItem instanceof HTMLElement)) continue
+      // eventItem should have only one className
+      if (events.indexOf(eventItem.className) < 0) continue
+      // First link is actor. I know this is not great.
+      const actor = eventItem.querySelector('a')
+      if (!actor) continue
+      const fromFollowedPeople= following.indexOf(actor.pathname.slice(1)) >= 0
+      eventItem.classList.add(fromFollowedPeople ? 'by_followed_people' : 'by_internet')
+    }
   }
 }

--- a/dashboard.js
+++ b/dashboard.js
@@ -109,7 +109,7 @@ function init () {
   } else {
     // org or user condition
     summary.classList.remove('btn-sm')
-    details.classList.add(isOrg ? 'mt-3' : 'mt-5')
+    details.classList.add(context === 'org' ? 'mt-3' : 'mt-5')
     document.querySelector('.news').prepend(details)
   }
   applyPreference()


### PR DESCRIPTION
- Fetches list of people user is following from public github API, updates at most once every 24h
- Use the following list to tell apart activities from people user follows and activities from internet people (following user/forking or starring user's repos)
- Adds an `org` context which has a different set of menu options and option are saved according to context.
- Adds `member_add` event under org admin

## user

<img src="https://user-images.githubusercontent.com/1153134/45001478-583d3c80-af9b-11e8-93bd-c0b1942d413c.png" width="300">

## org

<img src="https://user-images.githubusercontent.com/1153134/45001513-9aff1480-af9b-11e8-9585-21873f8b0cf3.png" width="300">
